### PR TITLE
[codex] Workspace 관리 API 실행 설정 보강

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 - `buildGroup`: Maven groupId
 - `buildVersion`: 애플리케이션 버전
 - `javaVersion`: 사용 JDK 버전
+- 하위 호환 키도 지원: `buildApplicationGroup`, `buildApplicationVersion`, `sourceCompatibility`, `targetCompatibility`
 
 ### 라이브러리 버전
 - `studioOneVersion`
@@ -18,9 +19,14 @@
 - `apachePoiVersion`
 - `log4jdbcLog4j2Version`
 
+### Workspace management API
+- `/api/mgmt/workspaces` 계열 API는 `studio-platform-starter-workspace` 의존성과 `studio.features.workspace.enabled=true`, `studio.features.workspace.web.enabled=true` 설정이 필요합니다.
+- Flyway에는 `classpath:/schema/workspace/{db}` location이 포함되어야 `TB_PLATFORM_WORKSPACE`, `TB_PLATFORM_WORKSPACE_CLOSURE`, `TB_PLATFORM_WORKSPACE_MEMBER`가 생성됩니다.
+
 ### Nexus 저장소
 - `nexus.releasesUrl`: 사내 Nexus URL
 - `nexus.allowInsecure`: HTTPS 미사용 시 `true`
+- 로컬 `studio-api` checkout을 직접 연결해 검증하려면 `-PuseStudioApiComposite=true -PstudioApiDir=/path/to/studio-api`를 함께 전달합니다.
 
 ### 보안/암호화
 - `JASYPT_ENCRYPTOR_PASSWORD`: Jasypt 암호화 키

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,19 +1,32 @@
 plugins {
-    id("org.springframework.boot") version "2.7.18"
-    id("io.spring.dependency-management") version "1.1.7" 
+    id("org.springframework.boot")
+    id("io.spring.dependency-management")
     war
     java
 }
-group = project.findProperty("buildGroup") as String
-version = project.findProperty("buildVersion") as String 
+
+fun prop(vararg keys: String, default: String? = null): String {
+    for (key in keys) {
+        val value = findProperty(key)?.toString()?.trim()
+        if (!value.isNullOrEmpty()) {
+            return value
+        }
+    }
+    return default ?: error("Missing Gradle property. Expected one of: ${keys.joinToString()}")
+}
+
+group = prop("buildGroup", "buildApplicationGroup")
+version = prop("buildVersion", "buildApplicationVersion")
 val profile = project.findProperty("profile") as String? ?: "dev"
 val isDev = profile == "dev"
 val packaging = (findProperty("packaging") as String?) ?: "jar"   
 val isWar = packaging.equals("war", ignoreCase = true)
 logger.lifecycle("📦 [PROFILE] = $profile (isDev=$isDev)")
+val javaVersion = prop("javaVersion", "sourceCompatibility", "targetCompatibility", default = "17")
+val studioApiVersion = prop("studioOneVersion", default = "2.0.0")
 java { 
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of((findProperty("javaVersion") as String).toInt()))
+        languageVersion.set(JavaLanguageVersion.of(javaVersion.toInt()))
     } 
     withSourcesJar()
     withJavadocJar()
@@ -25,27 +38,25 @@ dependencies {
         implementation("org.springframework.boot:spring-boot-starter-tomcat")
     }
     // studio one platform starters
-    implementation("studio.one.starter:studio-platform-starter:${property("studioOneVersion")}")
-    implementation("studio.one.starter:studio-platform-starter-jasypt:${property("studioOneVersion")}")
-    implementation("studio.one.starter:studio-platform-starter-objecttype:${property("studioOneVersion")}")
-    implementation("studio.one.starter:studio-platform-starter-user:${property("studioOneVersion")}")
-    implementation("studio.one.starter:studio-platform-starter-security:${property("studioOneVersion")}")
-    implementation("studio.one.starter:studio-platform-starter-security-acl:${property("studioOneVersion")}")
-    implementation("studio.one.starter:studio-platform-starter-objectstorage:${property("studioOneVersion")}")
-    implementation("studio.one.starter:studio-platform-starter-objectstorage-aws:${property("studioOneVersion")}")
-    implementation("studio.one.starter:studio-platform-starter-ai:${property("studioOneVersion")}")
-    implementation("studio.one.starter:studio-platform-starter-realtime:${property("studioOneVersion")}")
+    implementation("studio.one.starter:studio-platform-starter:$studioApiVersion")
+    implementation("studio.one.starter:studio-platform-starter-jasypt:$studioApiVersion")
+    implementation("studio.one.starter:studio-platform-starter-objecttype:$studioApiVersion")
+    implementation("studio.one.starter:studio-platform-starter-user:$studioApiVersion")
+    implementation("studio.one.starter:studio-platform-starter-security:$studioApiVersion")
+    implementation("studio.one.starter:studio-platform-starter-security-acl:$studioApiVersion")
+    implementation("studio.one.starter:studio-platform-starter-objectstorage:$studioApiVersion")
+    implementation("studio.one.starter:studio-platform-starter-objectstorage-aws:$studioApiVersion")
+    implementation("studio.one.starter:studio-platform-starter-ai:$studioApiVersion")
+    implementation("studio.one.starter:studio-platform-starter-realtime:$studioApiVersion")
+    implementation("studio.one.starter:studio-platform-starter-workspace:$studioApiVersion")
     // studio one platform applicaiton module & starters
-    implementation("studio.one.starter:studio-application-starter-avatar:${property("studioOneVersion")}")
-    implementation("studio.one.starter:studio-application-starter-attachment:${property("studioOneVersion")}") 
-    implementation("studio.one.starter:studio-application-starter-mail:${property("studioOneVersion")}") 
-    implementation("studio.one.starter:studio-application-starter-template:${property("studioOneVersion")}")         
-    implementation("studio.one.modules:content-embedding-pipeline:${property("studioOneVersion")}")
-    implementation("studio.one.starter:studio-application-starter-pages:${property("studioOneVersion")}")   
-    implementation("studio.one.starter:studio-application-starter-forums:${property("studioOneVersion")}")  
-    implementation("studio.one.modules:content-embedding-pipeline:${property("studioOneVersion")}")
-    implementation("studio.one.api:studio-platform-identity:${property("studioOneVersion")}")
-    implementation("studio.one.api:studio-platform-user-default:${property("studioOneVersion")}")
+    implementation("studio.one.starter:studio-application-starter-avatar:$studioApiVersion")
+    implementation("studio.one.starter:studio-application-starter-attachment:$studioApiVersion")
+    implementation("studio.one.starter:studio-application-starter-mail:$studioApiVersion")
+    implementation("studio.one.starter:studio-application-starter-template:$studioApiVersion")
+    implementation("studio.one.modules:content-embedding-pipeline:$studioApiVersion")
+    implementation("studio.one.api:studio-platform-identity:$studioApiVersion")
+    implementation("studio.one.api:studio-platform-user-default:$studioApiVersion")
     // srping starters 
     implementation("org.springframework.boot:spring-boot-starter-validation") 
     implementation("org.springframework.boot:spring-boot-starter-aop") 
@@ -62,7 +73,8 @@ dependencies {
     // database driver
     runtimeOnly("org.postgresql:postgresql:${project.findProperty("postgresqlVersion")}")    
     implementation("org.bgee.log4jdbc-log4j2:log4jdbc-log4j2-jdbc4.1:${project.findProperty("log4jdbcLog4j2Version")}")
-    implementation("org.flywaydb:flyway-core")
+    implementation("org.flywaydb:flyway-core:${project.findProperty("flywayVersion")}")
+    implementation("org.flywaydb:flyway-database-postgresql:${project.findProperty("flywayVersion")}")
     //test
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     //lombok

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,33 +1,42 @@
 # PROJECT
-buildApplicationGroup=studio.api
-buildApplicationName=studio-api
-buildApplicationVersion=0.0.1
-sourceCompatibility=11
-targetCompatibility=11 
-#libraries
-springBootVersion=2.7.18
-springDependencyManagementVersion=1.1.4
+buildGroup=studio.one.api
+buildVersion=2.0.0
+javaVersion=17
+studioOneVersion=2.0.0
+buildApplicationGroup=studio.one.api
+buildApplicationName=studio-one-api-server
+buildApplicationVersion=2.0.0
+sourceCompatibility=17
+targetCompatibility=17
+
+# libraries
+springBootVersion=3.5.9
+springDependencyManagementVersion=1.1.7
 egovframeVersion=4.3.0
 lombokVersion=1.18.30
 owaspDependencycheckVersion=8.2.1
-apacheCommonsIoVersion=2.11.0
-apacheCommonsLang3Version=3.12.0
+apacheCommonsIoVersion=2.20.0
+apacheCommonsLang3Version=3.18.0
 mybatisSpringVersion=2.1.2
 mybatisVersion=3.5.16
-postgresqlVersion=42.7.7
+postgresqlVersion=42.7.10
+flywayVersion=11.19.1
+apachePdfBoxVersion=3.0.6
+apachePoiVersion=5.2.3
 log4jdbcLog4j2Version=1.16
 mapstructVersion=1.5.5.Final
 jsonwebtokenVersion=0.13.0
 # LOCAL CRYPTO 
 jasyptVersion=3.0.4
 bouncycastleVersion=1.79
-JASYPT_ENCRYPTOR_PASSWORD=podo007
+
+# Do not commit local secrets. Use environment variables or ~/.gradle/gradle.properties.
+# JASYPT_ENCRYPTOR_PASSWORD=
+
 # NEXUS ACCOUNT
-nexus.username=admin
-nexus.password=admin))&
 nexus.releasesUrl=http://localhost:8081/repository/maven-releases/
 nexus.snapshotsUrl=http://localhost:8081/repository/maven-snapshots/
 nexus.allowInsecure=true
+useStudioApiComposite=false
 
 org.gradle.parallel=true
-org.gradle.jvmargs=-Xmx1g -Dfile.encoding=UTF-8

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -7,9 +7,15 @@
 
 
 pluginManagement {
+    val springBootVersion: String by settings
+    val springDependencyManagementVersion: String by settings
     repositories {
         gradlePluginPortal()
         mavenCentral()
+    }
+    plugins {
+        id("org.springframework.boot") version springBootVersion
+        id("io.spring.dependency-management") version springDependencyManagementVersion
     }
 }
 dependencyResolutionManagement {
@@ -17,6 +23,7 @@ dependencyResolutionManagement {
     repositories {
         // 1) 오픈소스를 위한 중앙 저장소
         mavenCentral()
+        mavenLocal()
         //2) 사내 Nexus 저장소
         val allowInsecure = providers.gradleProperty("nexus.allowInsecure")
             .orNull
@@ -33,4 +40,21 @@ plugins {
     // Apply the foojay-resolver plugin to allow automatic download of JDKs
     id("org.gradle.toolchains.foojay-resolver-convention") version "0.9.0"
 }
-rootProject.name = "studio-one-api-server"
+rootProject.name = providers.gradleProperty("buildApplicationName").getOrElse("studio-one-api-server")
+
+val useStudioApiComposite = providers.gradleProperty("useStudioApiComposite")
+    .orNull
+    ?.toBoolean()
+    ?: false
+if (useStudioApiComposite) {
+    val studioApiDir = providers.gradleProperty("studioApiDir")
+        .orNull
+        ?.takeIf { it.isNotBlank() }
+        ?.let(::file)
+        ?: error("studioApiDir is required when useStudioApiComposite=true")
+    require(studioApiDir.isDirectory) {
+        "studioApiDir does not exist: ${studioApiDir.absolutePath}"
+    }
+    logger.lifecycle("Including studio-api composite build from ${studioApiDir.absolutePath}")
+    includeBuild(studioApiDir)
+}

--- a/src/main/java/com/podosoftware/cufit/web/config/SecurityFilterConfig.java
+++ b/src/main/java/com/podosoftware/cufit/web/config/SecurityFilterConfig.java
@@ -32,7 +32,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
 import org.springframework.security.authentication.AuthenticationManager;
-import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.annotation.web.configurers.ExceptionHandlingConfigurer;
@@ -72,7 +72,7 @@ import studio.one.platform.util.LogUtils;
  */
 
 @Configuration
-@EnableGlobalMethodSecurity(prePostEnabled = true)
+@EnableMethodSecurity(prePostEnabled = true)
 @EnableConfigurationProperties(SecurityProperties.class)
 @RequiredArgsConstructor
 @Slf4j
@@ -121,7 +121,7 @@ public class SecurityFilterConfig {
         JwtProperties jwtProps = securityProperties.getJwt();
 
         HttpSecurity configured = http
-                .antMatcher("/api/**")
+                .securityMatcher("/api/**")
                 // .csrf(csrf -> csrf.ignoringAntMatchers(
                 //         buildCsrfIgnored(formLogin, logout, jwtProps).toArray(new String[0])))
                 .csrf(xcsrf-> xcsrf.disable()   )
@@ -129,13 +129,13 @@ public class SecurityFilterConfig {
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(authz -> {
                     for (String pattern : jwtOpenPatterns(securityProperties)) {
-                        authz.antMatchers(pattern).permitAll();
+                        authz.requestMatchers(pattern).permitAll();
                     }
                     securityProperties.getPermit().getPermitAll().forEach(path -> {
-                        authz.antMatchers(path).permitAll();
+                        authz.requestMatchers(path).permitAll();
                     });
                     securityProperties.getPermit().getRole().forEach((role, paths) -> paths.forEach(path -> {
-                        authz.antMatchers(path).hasRole(role);
+                        authz.requestMatchers(path).hasRole(role);
                     }));
                     authz.anyRequest().authenticated();
                 })
@@ -170,24 +170,24 @@ public class SecurityFilterConfig {
         LogoutProperties logout = securityProperties.getLogout();
         JwtProperties jwtProps = securityProperties.getJwt();
         HttpSecurity configured = http
-                .antMatcher("/**")
-                .csrf(csrf -> csrf.ignoringAntMatchers(
+                .securityMatcher("/**")
+                .csrf(csrf -> csrf.ignoringRequestMatchers(
                         buildCsrfIgnored(formLogin, logout, jwtProps).toArray(new String[0])))
                 .cors(cors -> cors.configurationSource(corsConfigurationSource))
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED))
                 .authorizeHttpRequests(authz -> {
                     if (formLogin.isEnabled()) {
-                        authz.antMatchers(formLogin.getLoginPage()).permitAll();
-                        authz.antMatchers(formLogin.getLoginProcessingUrl()).permitAll();
+                        authz.requestMatchers(formLogin.getLoginPage()).permitAll();
+                        authz.requestMatchers(formLogin.getLoginProcessingUrl()).permitAll();
                     }
                     if (logout.isEnabled()) {
-                        authz.antMatchers(logout.getLogoutUrl()).permitAll();
+                        authz.requestMatchers(logout.getLogoutUrl()).permitAll();
                     }
                     securityProperties.getPermit().getPermitAll().forEach(path -> {
-                        authz.antMatchers(path).permitAll();
+                        authz.requestMatchers(path).permitAll();
                     });
                     securityProperties.getPermit().getRole().forEach((role, paths) -> paths.forEach(path -> {
-                        authz.antMatchers(path).hasRole(role);
+                        authz.requestMatchers(path).hasRole(role);
                     }));
                     authz.anyRequest().authenticated();
                 })

--- a/src/main/resources/config/application-dev.yml
+++ b/src/main/resources/config/application-dev.yml
@@ -23,7 +23,7 @@ spring:
   application:
     name: cufit
   flyway:
-    enabled: false
+    enabled: true
     baseline-on-migrate: true
     baseline-version: 0
     validate-on-migrate: true
@@ -37,6 +37,7 @@ spring:
       - classpath:/schema/user/postgres
       - classpath:/schema/security/postgres
       - classpath:/schema/security-acl/postgres
+      - classpath:/schema/workspace/postgres
       - classpath:/schema/ai/postgres
       - classpath:/schema/avatar/postgres
       - classpath:/schema/attachment/postgres
@@ -45,7 +46,7 @@ spring:
     out-of-order: true
   ### JPA Config ###
   jpa:
-    database-platform: org.hibernate.dialect.PostgreSQL10Dialect
+    database-platform: org.hibernate.dialect.PostgreSQLDialect
     show-sql: false
     properties:
       hibernate:
@@ -212,6 +213,12 @@ studio:
       enabled: true
     template:
       enabled: true  
+    workspace:
+      enabled: true
+      web:
+        enabled: true
+        public-base-path: /api/workspaces
+        mgmt-base-path: /api/mgmt/workspaces
     text:
       enabled: true          
     user:


### PR DESCRIPTION
## Summary
- `studio-one-api-server` 런타임을 `studio-api 2.x` 기준 Java 17/Spring Boot 3.5 설정으로 정렬했습니다.
- `/api/mgmt/workspaces`가 실제 실행 서버에서 등록되도록 workspace starter 의존성, Flyway workspace schema location, workspace feature/web 설정을 추가했습니다.
- Spring Security 6 API에 맞춰 `SecurityFilterConfig`의 matcher 설정을 갱신했습니다.

## Root Cause
- 실행 서버 classpath에 `studio-platform-starter-workspace`가 없어 workspace controller/service 자동구성이 로딩되지 않았습니다.
- dev Flyway location에도 `schema/workspace/postgres`가 없어 workspace 테이블 생성 경로가 빠져 있었습니다.
- 원격 `2.x`는 Gradle 속성명이 맞지 않아 그대로는 2.x 모듈 검증을 시작할 수 없었습니다.

## Issue
- Closes donghyuck/studio-api#414

## Validation
- `./gradlew -PuseStudioApiComposite=true -PstudioApiDir=/Users/donghyuck.son/git/studio-api dependencyInsight --dependency studio-platform-starter-workspace --configuration runtimeClasspath`
- `./gradlew -PuseStudioApiComposite=true -PstudioApiDir=/Users/donghyuck.son/git/studio-api test`
- `git diff --check`

## Notes
- PR에는 로컬 기존 dirty worktree를 직접 stage하지 않고, clean worktree에서 #414에 필요한 변경만 재적용했습니다.
- `studioApiDir`는 로컬 검증용 Gradle property이며 기본값으로 특정 사용자 경로를 사용하지 않습니다.
