### PR TITLE
[ai-assisted] feat(runtime): dev 서버 지식 파이프라인 통합

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,9 +139,23 @@ java -jar build/libs/*.jar --spring.profiles.active=dev
 ```
 
 ### 접속 정보
-- JDBC: `jdbc:log4jdbc:postgresql://localhost:5432/studio_db`
+- JDBC: `jdbc:postgresql://localhost:5432/studio_db`
 - Username: `studioapi`
 - Password: `studioapi`
+
+### JDBC SQL logging
+
+`LOG4JDBC_ENABLED=false`가 기본값이다. 이 상태에서는 `DATASOURCE_URL`이 기존
+`jdbc:log4jdbc:` 형식이어도 서버가 일반 JDBC URL과 driver로 변환해 batch SQL 문자열 생성 비용을
+피한다. SQL 진단이 필요할 때만 다음과 같이 제한적으로 활성화한다.
+
+```text
+LOG4JDBC_ENABLED=true
+LOG4JDBC_SQLTIMING_LEVEL=INFO
+```
+
+`LOG4JDBC_SQLONLY_LEVEL`, `LOG4JDBC_AUDIT_LEVEL`, `LOG4JDBC_RESULTSET_LEVEL`,
+`LOG4JDBC_RESULTSETTABLE_LEVEL`, `LOG4JDBC_CONNECTION_LEVEL`은 기본 `OFF`이며 필요할 때만 켠다.
 
 ## 보안 주의사항
 - `gradle.properties`에는 민감정보가 포함될 수 있으므로, 실제 값은 사내 보안 정책에 맞게 관리하세요.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -71,6 +71,7 @@ dependencies {
         implementation("studio.one.starter:studio-platform-starter-ai:$studioApiVersion")
         implementation("studio.one.starter:studio-platform-starter-ai-web:$studioApiVersion")
         implementation("studio.one.starter:studio-platform-starter-chunking:$studioApiVersion")
+        implementation("studio.one.starter:studio-platform-starter-skillgraph:$studioApiVersion")
         implementation("studio.one.starter:studio-platform-starter-realtime:$studioApiVersion")
         implementation("studio.one.starter:studio-platform-starter-workspace:$studioApiVersion")
         implementation("studio.one.starter:studio-platform-thumbnail-starter:$studioApiVersion")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -71,6 +71,8 @@ dependencies {
         implementation("studio.one.starter:studio-platform-starter-ai:$studioApiVersion")
         implementation("studio.one.starter:studio-platform-starter-ai-web:$studioApiVersion")
         implementation("studio.one.starter:studio-platform-starter-chunking:$studioApiVersion")
+        implementation("studio.one.starter:studio-platform-starter-document-convert:$studioApiVersion")
+        implementation("studio.one.starter:studio-platform-starter-markdown:$studioApiVersion")
         implementation("studio.one.starter:studio-platform-starter-skillgraph:$studioApiVersion")
         implementation("studio.one.starter:studio-platform-starter-realtime:$studioApiVersion")
         implementation("studio.one.starter:studio-platform-starter-workspace:$studioApiVersion")

--- a/scripts/run-dev.sh
+++ b/scripts/run-dev.sh
@@ -45,6 +45,12 @@ fi
 
 : "${NEXUS_RELEASES_URL:=http://localhost:8081/repository/maven-releases/}"
 : "${NEXUS_ALLOW_INSECURE:=true}"
+: "${STUDIO_DEV_JAVA_OPTS:=-Xmx2g}"
+
+if [[ -n "${STUDIO_DEV_JAVA_OPTS}" ]]; then
+  export JAVA_TOOL_OPTIONS="${JAVA_TOOL_OPTIONS:+${JAVA_TOOL_OPTIONS} }${STUDIO_DEV_JAVA_OPTS}"
+  echo "OK: applied STUDIO_DEV_JAVA_OPTS"
+fi
 
 gradle_args=(
   "bootRun"

--- a/src/main/java/com/podosoftware/cufit/web/config/DataSourceConfig.java
+++ b/src/main/java/com/podosoftware/cufit/web/config/DataSourceConfig.java
@@ -26,6 +26,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
@@ -34,7 +35,12 @@ import org.springframework.transaction.PlatformTransactionManager;
 
 @Configuration
 @ConditionalOnClass(name = "javax.sql.DataSource")
+@EnableConfigurationProperties(DataSourceLoggingProperties.class)
 public class DataSourceConfig {
+
+    static final String LOG4JDBC_PREFIX = "jdbc:log4jdbc:";
+    static final String JDBC_PREFIX = "jdbc:";
+    static final String LOG4JDBC_DRIVER = "net.sf.log4jdbc.sql.jdbcapi.DriverSpy";
 
     @Bean(name = "primaryDataSourceProperties")
     @ConfigurationProperties("spring.datasource.primary")
@@ -44,10 +50,46 @@ public class DataSourceConfig {
 
     @Primary
     @Bean(name = "primaryDataSource")
-    public javax.sql.DataSource dataSource(@Qualifier("primaryDataSourceProperties") DataSourceProperties properties) {
+    public javax.sql.DataSource dataSource(
+            @Qualifier("primaryDataSourceProperties") DataSourceProperties properties,
+            DataSourceLoggingProperties loggingProperties) {
+        applyLoggingMode(properties, loggingProperties.isEnabled());
         return properties
                 .initializeDataSourceBuilder()
                 .build();
+    }
+
+    static void applyLoggingMode(DataSourceProperties properties, boolean enabled) {
+        String url = properties.getUrl();
+        if (url == null || url.isBlank()) {
+            return;
+        }
+        if (enabled) {
+            properties.setUrl(toLog4JdbcUrl(url));
+            properties.setDriverClassName(LOG4JDBC_DRIVER);
+            return;
+        }
+        properties.setUrl(toNativeJdbcUrl(url));
+        if (LOG4JDBC_DRIVER.equals(properties.getDriverClassName())) {
+            properties.setDriverClassName(null);
+        }
+    }
+
+    private static String toLog4JdbcUrl(String url) {
+        if (url.startsWith(LOG4JDBC_PREFIX)) {
+            return url;
+        }
+        if (url.startsWith(JDBC_PREFIX)) {
+            return LOG4JDBC_PREFIX + url.substring(JDBC_PREFIX.length());
+        }
+        throw new IllegalArgumentException("Unsupported JDBC URL: expected a jdbc: prefix");
+    }
+
+    private static String toNativeJdbcUrl(String url) {
+        if (url.startsWith(LOG4JDBC_PREFIX)) {
+            return JDBC_PREFIX + url.substring(LOG4JDBC_PREFIX.length());
+        }
+        return url;
     }
 
     @Bean(name = "transactionManager")

--- a/src/main/java/com/podosoftware/cufit/web/config/DataSourceLoggingProperties.java
+++ b/src/main/java/com/podosoftware/cufit/web/config/DataSourceLoggingProperties.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+package com.podosoftware.cufit.web.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties("studio.datasource.logging")
+public class DataSourceLoggingProperties {
+
+    private boolean enabled;
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+}

--- a/src/main/resources/config/application-dev.yml
+++ b/src/main/resources/config/application-dev.yml
@@ -39,6 +39,7 @@ spring:
       - classpath:/schema/security-acl/postgres
       - classpath:/schema/workspace/postgres
       - classpath:/schema/ai/postgres
+      - classpath:/schema/skillgraph/postgres
       - classpath:/schema/avatar/postgres
       - classpath:/schema/attachment/postgres
       - classpath:/schema/template/postgres
@@ -224,6 +225,10 @@ studio:
         enabled: true
         base-path: /api/object-types
         mgmt-base-path: /api/mgmt/object-types
+    skillgraph:
+      enabled: true
+      web:
+        enabled: true
   attachment:
     storage:
       base-dir: var/lib/app/files
@@ -294,6 +299,8 @@ studio:
         enabled: true
         ttl-seconds: 300
         max-size: 1000
+  skillgraph:
+    persistence: jdbc
   chunking:
     enabled: true
     strategy: recursive
@@ -407,6 +414,14 @@ studio:
       audit-enabled: true
       defaults:
         enabled: true
+        policies:
+          - domain: features
+            component: skillgraph
+            roles:
+              - role: ROLE_ADMIN
+                actions: [READ, WRITE, ADMIN]
+              - role: ROLE_DEVELOPER
+                actions: [READ]
       sync:
         enabled: true
       web:

--- a/src/main/resources/config/application-dev.yml
+++ b/src/main/resources/config/application-dev.yml
@@ -16,13 +16,13 @@ logging:
     org.hibernate: ERROR
     dev.langchain4j: DEBUG
     com.zaxxer.hikari: ERROR
-    log4jdbc.log4j2: WARN
-    jdbc.sqlonly: INFO
-    jdbc.sqltiming: INFO
-    jdbc.audit: WARN
-    jdbc.resultset: WARN
-    jdbc.resultsettable: WARN
-    jdbc.connection: WARN
+    log4jdbc.log4j2: ${LOG4JDBC_INTERNAL_LEVEL:WARN}
+    jdbc.sqlonly: ${LOG4JDBC_SQLONLY_LEVEL:OFF}
+    jdbc.sqltiming: ${LOG4JDBC_SQLTIMING_LEVEL:OFF}
+    jdbc.audit: ${LOG4JDBC_AUDIT_LEVEL:OFF}
+    jdbc.resultset: ${LOG4JDBC_RESULTSET_LEVEL:OFF}
+    jdbc.resultsettable: ${LOG4JDBC_RESULTSETTABLE_LEVEL:OFF}
+    jdbc.connection: ${LOG4JDBC_CONNECTION_LEVEL:OFF}
     #org.springframework.security.access.intercept.aopalliance.MethodSecurityInterceptor: DEBUG
     #org.springframework.security.access.expression.method: DEBUG
     studio.one.platform: debug
@@ -74,7 +74,6 @@ spring:
   datasource:
     primary:
       url: ${DATASOURCE_URL}
-      driver-class-name: net.sf.log4jdbc.sql.jdbcapi.DriverSpy
       username: ${DATASOURCE_USERNAME}
       password: ${DATASOURCE_PASSWORD}
       type: com.zaxxer.hikari.HikariDataSource
@@ -101,6 +100,13 @@ spring:
       max-request-size: 200MB # 요청 전체(여러 파일 합) 최대 크기
       file-size-threshold: 0 # 0이면 디스크로 바로 저장(메모리에 안 쌓음)
   ai:
+    openai:
+      api-key: ${LOCAL_GEMMA_API_KEY:local-dev}
+      base-url: ${LOCAL_GEMMA_BASE_URL:http://192.168.88.69:8000}
+      chat:
+        enabled: true
+        options:
+          model: ${LOCAL_GEMMA_CHAT_MODEL:gemma-3-4b}
     google:
       genai:
         chat:
@@ -128,6 +134,9 @@ management:
         include: mappings # 또는 "*"
 studio:
   banner-mode: off
+  datasource:
+    logging:
+      enabled: ${LOG4JDBC_ENABLED:false}
   env:
     log:
       enabled: false
@@ -277,8 +286,13 @@ studio:
       max-retry-count: 2
   markdown:
     enabled: true
-    max-source-bytes: 26214400
+    max-source-bytes: 64M
     pandoc-version: pandoc
+    pandoc-formats:
+      - docx
+      - html
+    fallback-to-native-on-pandoc-failure: true
+    result-cache-dir: var/lib/app/markdown
     textract-version: native
   textract:
     max-extract-size: 50M
@@ -288,12 +302,71 @@ studio:
     pdf:
       engine: pymupdf4llm
       fallback-enabled: true
+      ocr-fallback:
+        enabled: true
+        max-pages: 20
+        dpi: 180
       engines:
         pymupdf4llm:
           enabled: true
           endpoint: http://localhost:8000/extract/pdf
-          timeout: 60s
+          timeout: ${PYMUPDF4LLM_TIMEOUT:2m}
           max-file-size: 50MB
+        korean-ocr:
+          enabled: ${KOREAN_OCR_ENABLED:false}
+          endpoint: ${KOREAN_OCR_ENDPOINT:http://127.0.0.1:8603/extract/pdf}
+          timeout: ${KOREAN_OCR_TIMEOUT:2m}
+          max-file-size: ${KOREAN_OCR_MAX_FILE_SIZE:50MB}
+          max-pages: ${KOREAN_OCR_MAX_PAGES:64}
+          batch-size: ${KOREAN_OCR_BATCH_SIZE:2}
+          fallback-enabled: ${KOREAN_OCR_FALLBACK_ENABLED:true}
+          fallback-endpoint: ${KOREAN_OCR_FALLBACK_ENDPOINT:http://127.0.0.1:8000/extract/pdf}
+          fallback-batch-size: ${KOREAN_OCR_FALLBACK_BATCH_SIZE:2}
+        math:
+          enabled: ${MATH_OCR_ENABLED:true}
+          provider: ${MATH_OCR_PROVIDER:pix2text}
+          # 수학 OCR은 이 서버의 로컬 Pix2Text worker만 사용한다. 외부 provider는 명시 설정 전까지 사용하지 않는다.
+          fallback-providers: []
+          quality-gate:
+            enabled: ${MATH_OCR_QUALITY_GATE_ENABLED:true}
+            min-score: ${MATH_OCR_QUALITY_GATE_MIN_SCORE:0.65}
+          hybrid:
+            enabled: ${MATH_OCR_HYBRID_ENABLED:true}
+            sample-pages: ${MATH_OCR_HYBRID_SAMPLE_PAGES:8}
+            max-correction-pages: ${MATH_OCR_MAX_CORRECTION_PAGES:8}
+            fallback-pages: ${MATH_OCR_FALLBACK_PAGES:2}
+            wave-size: ${MATH_OCR_WAVE_SIZE:2}
+            time-budget: ${MATH_OCR_TIME_BUDGET:5m}
+          vision-correction:
+            enabled: ${MATH_VISION_CORRECTION_ENABLED:true}
+            provider: ${MATH_VISION_CORRECTION_PROVIDER:GEMINI}
+            gemini:
+              base-url: "${MATH_VISION_GEMINI_BASE_URL:https://generativelanguage.googleapis.com/v1beta}"
+              api-key: ${GEMINI_API_KEY:}
+              model: ${MATH_VISION_GEMINI_MODEL:gemini-2.5-flash}
+              timeout: ${MATH_VISION_GEMINI_TIMEOUT:5m}
+              max-file-size: ${MATH_VISION_GEMINI_MAX_FILE_SIZE:20MB}
+          pix2text:
+            endpoint: ${PIX2TEXT_MATH_OCR_ENDPOINT:http://127.0.0.1:8503/extract/pdf}
+            timeout: ${PIX2TEXT_MATH_OCR_TIMEOUT:5m}
+            max-file-size: ${PIX2TEXT_MATH_OCR_MAX_FILE_SIZE:50MB}
+            language: ${PIX2TEXT_MATH_OCR_LANGUAGE:ko,en}
+            page-by-page: ${PIX2TEXT_MATH_OCR_PAGE_BY_PAGE:true}
+            batch-size: ${PIX2TEXT_MATH_OCR_BATCH_SIZE:1}
+          mathpix:
+            api-base-url: ${MATHPIX_API_BASE_URL:https://api.mathpix.com/v3}
+            timeout: ${MATHPIX_TIMEOUT:5m}
+            poll-interval: ${MATHPIX_POLL_INTERVAL:2s}
+            max-poll-attempts: ${MATHPIX_MAX_POLL_ATTEMPTS:90}
+            app-id: ${MATHPIX_APP_ID:}
+            app-key: ${MATHPIX_APP_KEY:}
+      large-pdf:
+        enabled: true
+        page-threshold: 100
+        batch-size: 50
+        continue-on-part-failure: true
+        max-part-failures: 0
+        include-images: false
   thumbnail:
     enabled: true
     base-dir: var/lib/app/files/thumbnails
@@ -371,10 +444,15 @@ studio:
     strategy: recursive
     max-size: 800
     overlap: 100
+    blockify:
+      enabled: true
+      generator-type: llm
+      llm-provider: google-ai-gemini-2-5-flash
+      llm-model: gemini-2.5-flash
   ai:
     routing:
-      default-chat-provider: google-ai-gemini
-      default-embedding-provider: google-ai-gemini
+      default-chat-provider: google-ai-gemini-2-5-flash
+      default-embedding-provider: google-ai-gemini-embedding-001
     prompts:
       query-rewrite: "classpath:prompts/query-rewrite.v1.prompt"
       summarization: "classpath:prompts/summarization.v1.prompt"
@@ -389,8 +467,9 @@ studio:
         maximum-size: 1000
         ttl: 10m
       indexing:
-        embedding-batch-size: 8
-        upsert-batch-size: 32
+        embedding-batch-size: 4
+        upsert-batch-size: 64
+        chunk-write-batch-size: ${RAG_CHUNK_WRITE_BATCH_SIZE:25}
       retry:
         max-attempts: 3
         wait-duration: 2s
@@ -421,8 +500,18 @@ studio:
       default-embedding-profile: gemini-768
       embedding-profiles:
         gemini-768:
-          provider: google-ai-gemini
+          provider: google-ai-gemini-embedding-001
+          model: gemini-embedding-001
+          dimension: 768
           supported-input-types: [TEXT, TABLE_TEXT, IMAGE_CAPTION, OCR_TEXT]
+        gemini-embedding-2-768:
+          provider: google-ai-gemini-embedding-2
+          model: gemini-embedding-2
+          dimension: 768
+          supported-input-types: [TEXT, TABLE_TEXT, IMAGE_CAPTION, OCR_TEXT]
+          metadata:
+            lifecycle: current
+            multimodal-capable: true
         retrieval-ko-kure:
           provider: kure
           supported-input-types: [TEXT, TABLE_TEXT, IMAGE_CAPTION, OCR_TEXT]
@@ -436,23 +525,77 @@ studio:
           max-conversations: 1000
           ttl: 30m
     providers:
+      local-gemma:
+        enabled: true
+        type: OPENAI
+        base-url: ${LOCAL_GEMMA_BASE_URL:http://192.168.88.69:8000}
+        chat:
+          enabled: true
+          model: ${LOCAL_GEMMA_CHAT_MODEL:gemma-3-4b}
       kure:
         type: TEI
         enabled: true
-        base-url: http://localhost:18080
+        base-url: ${KURE_BASE_URL:${KURE_BASE_UTL:http://localhost:18080}}
         embedding:
           enabled: true
           model: nlpai-lab/KURE-v1
           dimension: 1024
-      google-ai-gemini:
+          request-timeout: 5m
+      google-ai-gemini-2-5-flash:
         enabled: true
         type: GOOGLE_AI_GEMINI
         chat:
           enabled: true
+          model: gemini-2.5-flash
+          model-override: true
+        embedding:
+          enabled: false
+      google-ai-gemini-2-5-pro:
+        enabled: true
+        type: GOOGLE_AI_GEMINI
+        chat:
+          enabled: true
+          model: gemini-2.5-pro
+          model-override: true
+        embedding:
+          enabled: false
+      google-ai-gemini-embedding-001:
+        enabled: true
+        type: GOOGLE_AI_GEMINI
+        chat:
+          enabled: false
         embedding:
           enabled: true
+          model: gemini-embedding-001
+          model-override: true
+          dimension: 768
         google-embedding:
           task-type: RETRIEVAL_DOCUMENT
+      google-ai-gemini-embedding-2:
+        enabled: true
+        type: GOOGLE_AI_GEMINI
+        chat:
+          enabled: false
+        embedding:
+          enabled: true
+          model: gemini-embedding-2
+          model-override: true
+          dimension: 768
+        google-embedding:
+          task-type: RETRIEVAL_DOCUMENT
+    usage:
+      enabled: true
+      currency: USD
+      pricing:
+        "[gemini-2.5-flash]":
+          input-per-million-tokens: 0.30
+          output-per-million-tokens: 2.50
+        "[gemini-2.5-pro]":
+          input-per-million-tokens: 1.25
+          output-per-million-tokens: 10.00
+          high-context-threshold-tokens: 200000
+          high-context-input-per-million-tokens: 2.50
+          high-context-output-per-million-tokens: 15.00
   cloud:
     storage:
       web:

--- a/src/main/resources/config/application-dev.yml
+++ b/src/main/resources/config/application-dev.yml
@@ -497,19 +497,29 @@ studio:
       keywords:
         scope: document
         max-input-chars: 4000
-      default-embedding-profile: gemini-768
+      default-embedding-profile: "google-ai/gemini-embedding-001@768"
       embedding-profiles:
-        gemini-768:
+        "google-ai/gemini-embedding-001@768":
           provider: google-ai-gemini-embedding-001
           model: gemini-embedding-001
-          dimension: 768
-          supported-input-types: [TEXT, TABLE_TEXT, IMAGE_CAPTION, OCR_TEXT]
-        gemini-embedding-2-768:
-          provider: google-ai-gemini-embedding-2
-          model: gemini-embedding-2
+          display-name: Google gemini-embedding-001 (Text, 768 dimensions)
+          aliases: [gemini-768]
           dimension: 768
           supported-input-types: [TEXT, TABLE_TEXT, IMAGE_CAPTION, OCR_TEXT]
           metadata:
+            providerId: google-ai
+            embeddingSpaceId: "google-ai/gemini-embedding-001@768"
+            modality: text
+        "google-ai/gemini-embedding-2@768":
+          provider: google-ai-gemini-embedding-2
+          model: gemini-embedding-2
+          display-name: Google gemini-embedding-2 (Multimodal, 768 dimensions)
+          aliases: [gemini-embedding-2-768]
+          dimension: 768
+          supported-input-types: [TEXT, TABLE_TEXT, IMAGE_CAPTION, OCR_TEXT]
+          metadata:
+            providerId: google-ai
+            embeddingSpaceId: "google-ai/gemini-embedding-2@768"
             lifecycle: current
             multimodal-capable: true
         retrieval-ko-kure:
@@ -581,8 +591,6 @@ studio:
           model: gemini-embedding-2
           model-override: true
           dimension: 768
-        google-embedding:
-          task-type: RETRIEVAL_DOCUMENT
     usage:
       enabled: true
       currency: USD

--- a/src/main/resources/config/application-dev.yml
+++ b/src/main/resources/config/application-dev.yml
@@ -16,14 +16,23 @@ logging:
     org.hibernate: ERROR
     dev.langchain4j: DEBUG
     com.zaxxer.hikari: ERROR
-    log4jdbc.log4j2: DEBUG
+    log4jdbc.log4j2: WARN
+    jdbc.sqlonly: INFO
+    jdbc.sqltiming: INFO
+    jdbc.audit: WARN
+    jdbc.resultset: WARN
+    jdbc.resultsettable: WARN
+    jdbc.connection: WARN
     #org.springframework.security.access.intercept.aopalliance.MethodSecurityInterceptor: DEBUG
     #org.springframework.security.access.expression.method: DEBUG
+    studio.one.platform: debug
 spring:
   application:
     name: studio-api
   flyway:
     enabled: true
+    schemas: ${DEFAULT_SCHEMA}
+    default-schema: ${DEFAULT_SCHEMA}
     baseline-on-migrate: true
     baseline-version: 0
     validate-on-migrate: true
@@ -42,6 +51,8 @@ spring:
       - classpath:/schema/skillgraph/postgres
       - classpath:/schema/avatar/postgres
       - classpath:/schema/attachment/postgres
+      - classpath:/schema/document-convert/postgres
+      - classpath:/schema/markdown/postgres
       - classpath:/schema/template/postgres
       - classpath:/schema/mail/postgres
     out-of-order: true
@@ -51,7 +62,7 @@ spring:
     show-sql: false
     properties:
       hibernate:
-        default_schema: studioapi
+        default_schema: ${DEFAULT_SCHEMA}
         format_sql: true
         jdbc:
           time_zone: UTC
@@ -62,10 +73,10 @@ spring:
   ### DATASOURCE Config ###
   datasource:
     primary:
-      url: jdbc:log4jdbc:postgresql://localhost:5432/studio_db
+      url: ${DATASOURCE_URL}
       driver-class-name: net.sf.log4jdbc.sql.jdbcapi.DriverSpy
-      username: studioapi
-      password: studioapi
+      username: ${DATASOURCE_USERNAME}
+      password: ${DATASOURCE_PASSWORD}
       type: com.zaxxer.hikari.HikariDataSource
       hikari:
         minimum-idle: 5 # 최소 유휴 커넥션 수
@@ -131,6 +142,22 @@ studio:
     fallback-to-system-locale: false
   persistence:
     type: jpa
+  bootstrap:
+    user:
+      enabled: true
+      roles:
+        - name: ROLE_ADMIN
+          description: administrator
+        - name: ROLE_USER
+          description: Default user
+      admin:
+        enabled: true
+        username: admin
+        password: ${STUDIO_BOOTSTRAP_ADMIN_PASSWORD}
+        email: admin@example.local
+        name: 스미스
+        roles:
+          - ROLE_ADMIN
   features:
     application-properties:
       enabled: true
@@ -231,14 +258,28 @@ studio:
         enabled: true
   attachment:
     storage:
-      base-dir: var/lib/app/files
+      #base-dir: var/lib/app/files
+      type: database
+      cache-enabled: true
     download-url:
-      public-base-url: http://localhost:8080
+      public-base-url: ${ATTACHMENT_DOWNLOAD_PUBLIC_BASE_URL:http://localhost:8080}
       signing-secret: ${ATTACHMENT_DOWNLOAD_URL_SIGNING_SECRET}
-    thumbnail:
-      enabled: true
-      base-dir: var/lib/app/files/thumbnails
-      ensure-dirs: true
+  document-convert:
+    enabled: true
+    callback-base-url: ${DOCUMENT_CONVERT_CALLBACK_BASE_URL:http://host.docker.internal:8080}
+    callback-token: ${DOCUMENT_CONVERT_CALLBACK_TOKEN}
+    worker:
+      base-url: ${PANDOC_WORKER_BASE_URL:http://localhost:8090}
+      internal-token: ${PANDOC_WORKER_INTERNAL_TOKEN}
+    storage:
+      signed-url-ttl: 10m
+    job:
+      max-retry-count: 2
+  markdown:
+    enabled: true
+    max-source-bytes: 26214400
+    pandoc-version: pandoc
+    textract-version: native
   textract:
     max-extract-size: 50M
     tesseract:
@@ -254,6 +295,9 @@ studio:
           timeout: 60s
           max-file-size: 50MB
   thumbnail:
+    enabled: true
+    base-dir: var/lib/app/files/thumbnails
+    ensure-dirs: true
     default-size: 128
     default-format: png
     min-size: 16
@@ -301,6 +345,27 @@ studio:
         max-size: 1000
   skillgraph:
     persistence: jdbc
+    extraction:
+      mode: llm
+      max-terms: 50
+      rag-job:
+        batch-size: 20
+        worker-count: 2
+        queue-capacity: 100
+        max-chunks: 5000
+        max-text-bytes-per-batch: 1000000
+        lease-duration: 2m
+        recovery-interval: 30s
+        max-auto-retries: 5
+      llm:
+        prompt: skill-extraction
+        max-input-chars: 4000
+        max-output-tokens: 1024
+        temperature: 0.0
+    matching:
+      remote-embedding-enabled: true
+    dataset-import:
+      enabled: true
   chunking:
     enabled: true
     strategy: recursive
@@ -315,12 +380,17 @@ studio:
       summarization: "classpath:prompts/summarization.v1.prompt"
       keyword-extraction: "classpath:prompts/keyword-extraction.v1.prompt"
       rag-cleaner: "classpath:prompts/rag-cleaner.v1.prompt"
+      skill-extraction: "classpath:prompts/skill-extraction.v1.prompt"
+      skill-category-naming: "classpath:prompts/skill-category-naming.v1.prompt"
     rag:
       jobs:
         repository: jdbc
       cache:
         maximum-size: 1000
         ttl: 10m
+      indexing:
+        embedding-batch-size: 8
+        upsert-batch-size: 32
       retry:
         max-attempts: 3
         wait-duration: 2s
@@ -352,9 +422,11 @@ studio:
       embedding-profiles:
         gemini-768:
           provider: google-ai-gemini
-          model: gemini-embedding-001
-          dimension: 768
           supported-input-types: [TEXT, TABLE_TEXT, IMAGE_CAPTION, OCR_TEXT]
+        retrieval-ko-kure:
+          provider: kure
+          supported-input-types: [TEXT, TABLE_TEXT, IMAGE_CAPTION, OCR_TEXT]
+
     endpoints:
       enabled: true
       chat:
@@ -364,6 +436,14 @@ studio:
           max-conversations: 1000
           ttl: 30m
     providers:
+      kure:
+        type: TEI
+        enabled: true
+        base-url: http://localhost:18080
+        embedding:
+          enabled: true
+          model: nlpai-lab/KURE-v1
+          dimension: 1024
       google-ai-gemini:
         enabled: true
         type: GOOGLE_AI_GEMINI
@@ -401,7 +481,7 @@ studio:
         - "http://localhost:3000"
         - "http://192.168.0.156:3000"
       sock-js: false # SockJS fallback 사용 여부
-      jwt-enabled: false # JwtDecoder 사용 시 true
+      jwt-enabled: true # STOMP CONNECT Authorization Bearer 검증
       redis-enabled: false # Redis Pub/Sub 사용 시 true
       redis-channel: studio:realtime:events
   security:
@@ -502,6 +582,7 @@ studio:
         - /api/users/*
         - /api/profile/*/avatar*
         - /api/attachments/signed-download
+        - /api/internal/document-conversions/**
         - /api/forums/**
         - /api/forums/*/topics/*/posts/*/attachments*
         - /actuator/**

--- a/src/test/java/com/podosoftware/cufit/web/config/DataSourceConfigTest.java
+++ b/src/test/java/com/podosoftware/cufit/web/config/DataSourceConfigTest.java
@@ -1,0 +1,60 @@
+package com.podosoftware.cufit.web.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
+
+class DataSourceConfigTest {
+
+    @Test
+    void disablesLog4JdbcForLegacyPrefixedUrl() {
+        DataSourceProperties properties = properties(
+                "jdbc:log4jdbc:postgresql://localhost:5432/studio",
+                DataSourceConfig.LOG4JDBC_DRIVER);
+
+        DataSourceConfig.applyLoggingMode(properties, false);
+
+        assertThat(properties.getUrl()).isEqualTo("jdbc:postgresql://localhost:5432/studio");
+        assertThat(properties.getDriverClassName()).isNull();
+    }
+
+    @Test
+    void enablesLog4JdbcForNativeUrl() {
+        DataSourceProperties properties = properties("jdbc:postgresql://localhost:5432/studio", null);
+
+        DataSourceConfig.applyLoggingMode(properties, true);
+
+        assertThat(properties.getUrl()).isEqualTo("jdbc:log4jdbc:postgresql://localhost:5432/studio");
+        assertThat(properties.getDriverClassName()).isEqualTo(DataSourceConfig.LOG4JDBC_DRIVER);
+    }
+
+    @Test
+    void keepsAlreadyConfiguredLog4JdbcUrl() {
+        DataSourceProperties properties = properties(
+                "jdbc:log4jdbc:postgresql://localhost:5432/studio",
+                DataSourceConfig.LOG4JDBC_DRIVER);
+
+        DataSourceConfig.applyLoggingMode(properties, true);
+
+        assertThat(properties.getUrl()).isEqualTo("jdbc:log4jdbc:postgresql://localhost:5432/studio");
+        assertThat(properties.getDriverClassName()).isEqualTo(DataSourceConfig.LOG4JDBC_DRIVER);
+    }
+
+    @Test
+    void rejectsNonJdbcUrlWhenLoggingIsEnabled() {
+        DataSourceProperties properties = properties("postgresql://localhost:5432/studio", null);
+
+        assertThatThrownBy(() -> DataSourceConfig.applyLoggingMode(properties, true))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("jdbc: prefix");
+    }
+
+    private DataSourceProperties properties(String url, String driverClassName) {
+        DataSourceProperties properties = new DataSourceProperties();
+        properties.setUrl(url);
+        properties.setDriverClassName(driverClassName);
+        return properties;
+    }
+}


### PR DESCRIPTION
## Why

- dev API 서버에서 SkillGraph와 첨부파일 Markdown 지식 파이프라인을 실제로 구동할 starter, migration, provider 설정이 필요하다.
- Pandoc, OCR, Pix2Text, KURE 및 Gemini provider를 로컬 개발 환경에서 일관되게 연결해야 한다.
- 대용량 청크 저장 중 `log4jdbc DriverSpy`가 batch SQL 문자열을 조립해 JVM heap을 소진하므로 운영 기본 경로에서 proxy를 제거해야 한다.

## What

- SkillGraph starter, Flyway schema, JDBC persistence 및 dev ACL 설정을 유지했다.
- document-convert와 Markdown starter 의존성 및 Flyway migration 경로를 추가했다.
- Attachment DB storage의 signed URL을 사용하는 Pandoc callback/worker 설정을 추가했다.
- 문서 프로필별 Markdown, Textract, OCR, Pix2Text/수식 보정 및 Thumbnail 설정을 추가했다.
- KURE 및 Gemini chat/embedding provider, embedding profile과 모델별 비용 설정을 정리했다.
- Google 임베딩 profile을 공식 모델명 기반 canonical ID로 변경하고 기존 ID는 alias로 유지했다.
- RAG embedding, vector upsert, chunk JDBC write batch 크기를 각각 설정할 수 있게 했다.
- `LOG4JDBC_ENABLED=false`를 기본값으로 두고 기존 `jdbc:log4jdbc:` URL도 native JDBC URL로 자동 변환한다.
- SQL logger category는 각각 환경변수로 제어하며 기본값을 `OFF`로 변경했다.

## Related Issues

- Closes donghyuck/studio-api#472
- Depends on donghyuck/studio-api#511
- Depends on donghyuck/studio-api#519
- Markdown 통합 및 log4jdbc 안정화 변경은 대화 기반 요청으로 별도 Issue 없음

## Validation

- `./gradlew test --tests com.podosoftware.cufit.web.config.DataSourceConfigTest --no-daemon` 성공
- 전체 `./gradlew test --no-daemon` 성공
- composite build를 포함한 서버 compile 성공
- `application-dev.yml` YAML parse 성공
- 서버 재시작 후 포트 `8080` listen 확인
- Flyway 연결 로그에서 `jdbc:postgresql:` native URL 확인
- 실행 로그에서 `DriverSpy`, `jdbc:log4jdbc`, batch SQL 출력이 없음을 확인
- `git diff --check` 성공

## Risk / Rollback

- SQL 진단 로그가 기본 비활성화되므로 필요할 때 `LOG4JDBC_ENABLED=true`와 개별 logger level을 명시해야 한다.
- `log4jdbc 1.16`은 logger가 `OFF`여도 proxy 사용 시 batch 문자열을 생성하므로 대용량 처리 중에는 활성화하지 않아야 한다.
- canonical ID 변경 후에도 기존 profile ID는 alias로 동작하며, 실제 모델이나 차원을 변경할 때는 재색인이 필요하다.

## AI / Subagent Usage

- AI-Assisted: Yes
- Codex를 사용해 구현, 설정 검증, 런타임 확인, 커밋 및 PR 문서를 작성했다.
- Subagent는 사용하지 않았다.

## Checklist

- [x] commit message follows policy
- [x] issue exception reason is recorded
- [x] validation is recorded
- [x] secrets and local logs are excluded
- [x] human review is required before merge