### PR TITLE
[3.x] Spring Boot 4 실행 서버 기준선 전환

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,48 @@
 # Studio One API Server
 
+## 3.x 실행 기준선
+
+`3.x` 서버는 Java 17, Gradle 8.14.5, Spring Boot 4.1.0, Spring AI 2.0.0 및
+`studio-api` `3.0.0-rc.1` artifact를 사용한다. 애플리케이션 JSON 경계는 Jackson 3이며
+MyBatis Spring Boot Starter 4 계열을 사용한다. 개발 worktree에서 플랫폼 소스를 composite
+build로 사용하려면 `-PstudioApiDir=/absolute/path/to/studio-api-3x`를 지정할 수 있다.
+
+2.x와 3.x Studio artifact를 한 runtime classpath에 혼합하지 않는다. 3.x 의존성 검증과
+rollback 기준은 platform 저장소의
+[3.x 업그레이드 기준선](https://github.com/donghyuck/studio-api/blob/3.x/docs/dev/3x-upgrade-baseline.md)을
+따른다.
+
+Spring Boot 4에서는 Flyway 자동구성이 별도 starter로 분리되므로
+`spring-boot-starter-flyway`와 대상 DB 모듈을 함께 유지해야 한다. `flyway-core`만 직접
+추가하면 migration이 실행되지 않은 채 Hibernate schema validation이 시작될 수 있다.
+
+RAG exact-answer cache는 기본적으로 비활성화되어 있으며 다음 환경변수로 전환한다.
+
+```text
+RAG_ANSWER_CACHE_TYPE=none
+RAG_ANSWER_CACHE_TTL=5m
+RAG_ANSWER_CACHE_NAMESPACE=studio:ai:rag-answer:v2
+SPRING_DATA_REDIS_HOST=127.0.0.1
+SPRING_DATA_REDIS_PORT=6379
+```
+
+Redis를 활성화해도 기존 `@Cacheable` 도메인 객체는 Caffeine에 남는다.
+`spring.cache.type=caffeine`은 RAG cache와 별개의 직렬화 경계를 보존하기 위한 설정이므로
+제거하지 않는다.
+
+권장 승격 순서는 다음과 같다.
+
+1. `RAG_ANSWER_CACHE_TYPE=none`으로 ApplicationContext, 인증, AI 정보, RAG sync/SSE를 확인한다.
+2. Redis 연결과 ACL/TLS를 확인하고 `RAG_ANSWER_CACHE_TYPE=redis`로 재기동한다.
+3. 동일 principal/object/evidence 질의에서 `MISS → HIT`를 확인한다.
+4. 문서 revision 또는 packed evidence를 변경했을 때 `MISS`인지 확인한다.
+5. Redis를 중지해도 provider 경로가 HTTP 200으로 응답하는지 확인한다.
+
+롤백할 때는 먼저 `RAG_ANSWER_CACHE_TYPE=none`으로 되돌린 뒤 2.x artifact와 2.1 property
+set을 함께 배포한다. v2 namespace는 이전 Jackson payload와 격리되어 있으므로 cache
+때문에 DB rollback을 수행할 필요는 없다. PostgreSQL이 별도 schema를 사용하면
+`DEFAULT_SCHEMA`와 JDBC URL의 `currentSchema`가 반드시 같은 schema를 가리켜야 한다.
+
 ## gradle.properties 설정 안내
 
 `gradle.properties`에는 빌드/의존성 버전 및 실행에 필요한 환경 설정이 포함됩니다. 아래 항목들을 확인하고, 환경에 맞게 값을 설정하세요.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -88,16 +88,15 @@ dependencies {
     }
     // spring starters
     implementation("org.springframework.boot:spring-boot-starter-validation")
-    implementation("org.springframework.boot:spring-boot-starter-aop")
-    implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.boot:spring-boot-starter-aspectj")
+    implementation("org.springframework.boot:spring-boot-starter-webmvc")
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("org.springframework.boot:spring-boot-starter-security")
     implementation("org.springframework.boot:spring-boot-starter-cache")
+    implementation("org.springframework.boot:spring-boot-starter-data-redis")
     implementation("com.github.ben-manes.caffeine:caffeine")
     implementation("org.springframework.boot:spring-boot-starter-mail")
     implementation("org.springframework.boot:spring-boot-starter-websocket")
-    compileOnly("javax.servlet:javax.servlet-api:4.0.1")
-
     implementation("org.springframework.ai:spring-ai-starter-model-openai")
     implementation("org.springframework.ai:spring-ai-google-genai")
     implementation("org.springframework.ai:spring-ai-google-genai-embedding")
@@ -107,7 +106,7 @@ dependencies {
     // database driver
     runtimeOnly("org.postgresql:postgresql:${project.findProperty("postgresqlVersion")}")    
     implementation("org.bgee.log4jdbc-log4j2:log4jdbc-log4j2-jdbc4.1:${project.findProperty("log4jdbcLog4j2Version")}")
-    implementation("org.flywaydb:flyway-core:${project.findProperty("flywayVersion")}")
+    implementation("org.springframework.boot:spring-boot-starter-flyway")
     implementation("org.flywaydb:flyway-database-postgresql:${project.findProperty("flywayVersion")}")
     //test
     testImplementation("org.springframework.boot:spring-boot-starter-test")

--- a/docker/postgres/init/01-init.sh
+++ b/docker/postgres/init/01-init.sh
@@ -11,15 +11,12 @@ BEGIN
   END IF;
 END
 $$;
-
-DO $$
-BEGIN
-  IF NOT EXISTS (SELECT 1 FROM pg_database WHERE datname = 'studio_db') THEN
-    CREATE DATABASE studio_db OWNER studioapi;
-  END IF;
-END
-$$;
 SQL
+
+if ! psql -v ON_ERROR_STOP=1 --username "postgres" --tuples-only --no-align \
+  --command "SELECT 1 FROM pg_database WHERE datname = 'studio_db'" | grep -qx 1; then
+  createdb --username "postgres" --owner "studioapi" "studio_db"
+fi
 
 psql -v ON_ERROR_STOP=1 --username "postgres" --dbname "studio_db" <<'SQL'
 CREATE SCHEMA IF NOT EXISTS studioapi AUTHORIZATION studioapi;

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,24 +3,24 @@ java.toolchain=17
 
 # PROJECT
 buildGroup=studio.one.api
-buildVersion=2.0.0
+buildVersion=3.0.0-rc.1
 javaVersion=17
-studioOneVersion=2.0.0
+studioOneVersion=3.0.0-rc.1
 buildApplicationGroup=studio.one.api
 buildModulesGroup=studio.one.modules
 buildStarterGroup=studio.one.starter
 buildApplicationName=studio-one-api-server
-buildApplicationVersion=2.0.0
+buildApplicationVersion=3.0.0-rc.1
 sourceCompatibility=17
 targetCompatibility=17
 
 # libraries
-springBootVersion=3.5.9
+springBootVersion=4.1.0
 springDependencyManagementVersion=1.1.7
 egovframeVersion=4.3.0
 lombokVersion=1.18.30
 apachePdfBoxVersion=3.0.6
-apachePoiVersion=5.2.3
+apachePoiVersion=5.5.1
 jsoupVersion=1.21.2
 postgresqlVersion=42.7.10
 flywayVersion=11.19.1

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -34,7 +34,7 @@ plugins {
 
 rootProject.name = providers.gradleProperty("buildApplicationName").get()
 
-val defaultStudioApiDir = file("/Users/donghyuck.son/git/studio-api")
+val defaultStudioApiDir = file("../studio-api-3x")
 val studioApiDir = providers.gradleProperty("studioApiDir")
     .orNull
     ?.takeIf { it.isNotBlank() }

--- a/src/main/java/com/podosoftware/cufit/StudioOneAll.java
+++ b/src/main/java/com/podosoftware/cufit/StudioOneAll.java
@@ -2,8 +2,8 @@ package com.podosoftware.cufit;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.boot.jdbc.autoconfigure.DataSourceAutoConfiguration;
 import org.springframework.scheduling.annotation.EnableAsync;
 
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/podosoftware/cufit/web/config/DataSourceConfig.java
+++ b/src/main/java/com/podosoftware/cufit/web/config/DataSourceConfig.java
@@ -24,9 +24,9 @@ import javax.sql.DataSource;
 
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
-import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.jdbc.autoconfigure.DataSourceProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;

--- a/src/main/resources/config/application-dev.yml
+++ b/src/main/resources/config/application-dev.yml
@@ -29,6 +29,11 @@ logging:
 spring:
   application:
     name: studio-api
+  cache:
+    # RAG exact-answer cache uses StringRedisTemplate directly. Keep existing
+    # @Cacheable domain objects in-process so enabling Redis does not change
+    # their serialization contract.
+    type: caffeine
   flyway:
     enabled: true
     schemas: ${DEFAULT_SCHEMA}
@@ -472,7 +477,7 @@ studio:
         workload: EMBEDDING
         normalization-policy: provider-default
         index-task-type: retrieval_document
-        query-task-type: retrieval_document
+        query-task-type: retrieval_query
         input-transform-id: text
         input-transform-version: "1"
       document-multimodal-v1:
@@ -480,8 +485,8 @@ studio:
         model-ref: google/gemini-embedding-2
         workload: EMBEDDING
         normalization-policy: provider-default
-        index-task-type: retrieval_document
-        query-task-type: retrieval_document
+        index-task-type: provider-default
+        query-task-type: provider-default
         input-transform-id: text
         input-transform-version: "1"
       retrieval-ko-kure-v1:
@@ -501,6 +506,11 @@ studio:
       skill-extraction: "classpath:prompts/skill-extraction.v1.prompt"
       skill-category-naming: "classpath:prompts/skill-category-naming.v1.prompt"
     rag:
+      answer-cache:
+        type: ${RAG_ANSWER_CACHE_TYPE:none}
+        ttl: ${RAG_ANSWER_CACHE_TTL:5m}
+        namespace: ${RAG_ANSWER_CACHE_NAMESPACE:studio:ai:rag-answer:v2}
+        fail-open: true
       jobs:
         repository: jdbc
       cache:
@@ -582,8 +592,6 @@ studio:
           enabled: true
         embedding:
           enabled: true
-        google-embedding:
-          task-type: RETRIEVAL_DOCUMENT
     usage:
       enabled: true
       currency: USD

--- a/src/test/java/com/podosoftware/cufit/web/config/AiModelDeploymentConfigurationSnapshotTest.java
+++ b/src/test/java/com/podosoftware/cufit/web/config/AiModelDeploymentConfigurationSnapshotTest.java
@@ -32,10 +32,10 @@ class AiModelDeploymentConfigurationSnapshotTest {
             "local-gemma-v1", new DeploymentSnapshot("local-gemma", "gemma-3-4b", null, null),
             "humanities-text-v1", new DeploymentSnapshot(
                     "google-ai", "gemini-embedding-001", 768,
-                    "es:v1:e41d6629354b5957dfd11ebd46976beedde68e59fd99a01ac3d74ca40fb110ba"),
+                    "es:v1:af68e66cba4cd2f685a1a2c5d3f9f43e1859c70926ac26f62449274626a7b068"),
             "document-multimodal-v1", new DeploymentSnapshot(
                     "google-ai", "gemini-embedding-2", 768,
-                    "es:v1:083d10ec2a0593bb0ed345777d98fba3729d4b251715840c2fd7074b498c6188"),
+                    "es:v1:1649bfdabe493e3a20e5078719dbe0577fbcca494cef88fd4acab1ab77374afa"),
             "retrieval-ko-kure-v1", new DeploymentSnapshot(
                     "kure", "nlpai-lab/KURE-v1", 1024,
                     "es:v1:eb99a8ed70abc5da4e432ea48281ce949c04602df3c38f70c58eb651d7d6a08a"));
@@ -43,6 +43,9 @@ class AiModelDeploymentConfigurationSnapshotTest {
     @Test
     void devDeploymentIdsResolveToReviewedModelsAndEmbeddingSpaces() throws IOException {
         Binder binder = binder("config/application-dev.yml");
+        assertThat(binder.bind("spring.cache.type", Bindable.of(String.class))
+                .orElseThrow(() -> new IllegalStateException("spring.cache.type is missing")))
+                .isEqualTo("caffeine");
         ModelDeploymentProperties properties = binder.bind(
                 "studio.ai", Bindable.of(ModelDeploymentProperties.class))
                 .orElseThrow(() -> new IllegalStateException("studio.ai deployment configuration is missing"));

--- a/src/test/java/com/podosoftware/cufit/web/config/DataSourceConfigTest.java
+++ b/src/test/java/com/podosoftware/cufit/web/config/DataSourceConfigTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
+import org.springframework.boot.jdbc.autoconfigure.DataSourceProperties;
 
 class DataSourceConfigTest {
 


### PR DESCRIPTION
## Why

- Studio platform 3.0.0-rc.1과 Spring Boot 4 runtime 계약을 실제 실행 서버에 동일하게 적용합니다.
- Redis RAG cache를 선택적으로 승격하면서 기존 domain cache와 rollback 경계를 보존합니다.

## What

- Gradle 8.14.5, Spring Boot 4.1.0, Studio 3.0.0-rc.1 의존성을 적용했습니다.
- Boot 4 MVC, AspectJ, Flyway PostgreSQL starter 구성을 반영했습니다.
- 기존 `@Cacheable` domain cache는 Caffeine으로 고정하고 RAG answer cache만 Redis를 직접 사용하도록 구성했습니다.
- PostgreSQL 초기화와 datasource schema 설정을 보완했습니다.
- README에 3.x 실행 기준선, cache 승격, fail-open 및 rollback 절차를 현행화했습니다.

## Related Issues

- Platform PR: https://github.com/donghyuck/studio-api/pull/525
- 별도 Issue 없음: 사용자가 3.x 실행 서버 전환과 PR 생성을 직접 요청했습니다.

## Validation

- Command: `./gradlew test --no-daemon`
  - Result: 성공, 147 tasks
- Runtime: ApplicationContext, root, actuator mappings, 보호 AI endpoint, login, AI info smoke test 성공
- RAG cache: none, redis MISS/HIT, revision invalidation, Redis 장애 fail-open, sync/SSE 검증 성공
- Rollback: origin/2.x server의 v2.1.0-rc.1 platform composite test와 runtime smoke test 성공
- Documentation: `git diff --check` 성공

## Risk / Rollback

- Risk: Platform PR보다 먼저 배포하거나 2.x와 3.x Studio artifact를 혼합하면 runtime classpath 오류가 발생할 수 있습니다.
- Rollback: `RAG_ANSWER_CACHE_TYPE`을 `none`으로 전환하고 2.x server와 v2.1.0-rc.1 platform 및 2.1 property set을 함께 복원합니다. 별도 schema 사용 시 `DEFAULT_SCHEMA`와 JDBC `currentSchema`를 동일하게 유지합니다.

## AI / Subagent Usage

- AI-assisted: Yes
- Subagent used: Yes
- Delegated scope: 플랫폼 기준선, Jackson 3, Spring AI 2, 계획 architecture/critic, 최종 upgrade verification 검토
- Main author validation: 서버 설정을 플랫폼 변경과 통합한 뒤 test, runtime, cache 및 rollback 검증을 직접 수행했습니다.

## Checklist

- [x] commit message follows policy
- [x] issue template used or exception recorded
- [x] AI-Assisted value is correct
- [x] validation recorded
- [x] subagent usage recorded when used
- [x] CI / repository verification passed locally
- [ ] human review completed before merge
- [x] no unrelated changes included
